### PR TITLE
tweak Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: gunicorn --chdir src my_resume:app
+web: gunicorn --chdir src my_resume:app

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,0 +1,1 @@
+../requirements.txt


### PR DESCRIPTION
still trying to fix: 

```
-----> Building on the Heroku-22 stack
-----> Using buildpack: heroku/python
-----> Python app detected
-----> Using Python version specified in runtime.txt
-----> Stack has changed from heroku-20 to heroku-22, clearing cache
cp: not writing through dangling symlink '/tmp/codon/tmp/cache/.heroku/requirements.txt'
 !     Push rejected, failed to compile Python app.
 !     Push failed
```